### PR TITLE
Changed the URL for the SendGrid API

### DIFF
--- a/src/Sendgrid/Core/Connect.php
+++ b/src/Sendgrid/Core/Connect.php
@@ -35,7 +35,7 @@ class Connect
      * sendgrid endpoint ...
      * @var string
      */
-    const SG_ENDPOINT = 'https://sendgrid.com/api';
+    const SG_ENDPOINT = 'https://api.sendgrid.com/api';
 
     /**
      * Creates a new SendGrid Newsletter API object to make calls with


### PR DESCRIPTION
The proper URL is https://api.sendgrid.com/api/ 

All of the SendGrid documentation has been updated to reflect this, but I noticed you were using the old URL. All new functionality will be added to https://api.sendgrid.com/api/ rather than https://sendgrid.com/api/ - so if you change this now, you will be ahead of the curve when things are updated on our end.
